### PR TITLE
Usability bug fixes

### DIFF
--- a/GRLD.tmLanguage
+++ b/GRLD.tmLanguage
@@ -137,7 +137,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>^(\[\d+\])\s*(.*)(\..*)(\s*:.*?\d+)\s*(\((.*?):.*\)|$)</string>
+			<string>^(\[\d+\])\s*(.*)(\..*)(\s*:.*?\d+).*(\((.*?):.*\)|$)</string>
 			<key>name</key>
 			<string>grld.output.stack.entry</string>
 		</dict>

--- a/grld/session.py
+++ b/grld/session.py
@@ -107,9 +107,10 @@ def update_socket_loop():
         try:
             protocol.update()
         except ProtocolConnectionException as e:
-            sublime.set_timeout(lambda: sublime.error_message('The connection to client was lost. Restarting SublimeTextGRLD server.'), 0)
-            sublime.set_timeout(lambda: sublime.active_window().send_command('grld_session_restart'), 0)
             return
+        #    sublime.set_timeout(lambda: sublime.error_message('The connection to client was lost. Restarting SublimeTextGRLD server.'), 0)
+        #    sublime.set_timeout(lambda: sublime.active_window().send_command('grld_session_restart'), 0)
+        #    return
 
     sublime.set_timeout_async(update_socket_loop, 100)
 

--- a/grld/session.py
+++ b/grld/session.py
@@ -539,7 +539,8 @@ class SocketHandler(threading.Thread):
             current_thread = protocol.read()
 
         # GRLD only passes back co-routines that are NOT 'main'. So, if current_thread is not in the list, then 'main' is the current thread.
-        if current_thread not in coroutines_dict.values():
+        coroutine_ids = (coroutine_descriptor['id'] for coroutine_descriptor in coroutines_dict.values())
+        if current_thread not in coroutine_ids:
             current_thread = 'main'
 
         self.current_thread = current_thread

--- a/grld/util.py
+++ b/grld/util.py
@@ -65,6 +65,7 @@ def get_real_path(uri, server=False):
     if isinstance(path_mapping, dict):
 
         found_path_mapping = False
+        found_parent_path_mapping = False
         
         # Go through path mappings
         for server_path, local_path in path_mapping.items():
@@ -84,8 +85,15 @@ def get_real_path(uri, server=False):
                     found_path_mapping = True
                     break
 
+            
+            if not found_path_mapping:
+                if server:
+                    found_parent_path_mapping = server_path in uri
+                else:
+                    found_parent_path_mapping = local_path in uri
+
         # "=[C]" is a special case url for lua C code
-        if not found_path_mapping and uri != '=[C]':
+        if not found_path_mapping and not found_parent_path_mapping and uri != '=[C]':
             server_or_local = 'server' if server else 'local'
             sublime.set_timeout(lambda: sublime.error_message("GRLD: No {} path mapping defined for path {}. It's likely that your breakpoints for this file won't be hit! You can set up path mappings in the SublimeTextGRLD package settings.".format(server_or_local, uri)), 0)
     else:

--- a/grld/view.py
+++ b/grld/view.py
@@ -144,7 +144,7 @@ def generate_context_output(context, indent=0, values_only=False, multiline=True
         if variable['value'] and len(variable['value']) > 0:
             value = variable['value'].replace("\r\n", "\n").replace("\n", " ")
 
-        if multiline:
+        if multiline or has_children:
             property_text += '\n'
         else:
             if not is_last_element:

--- a/grld/view.py
+++ b/grld/view.py
@@ -861,7 +861,7 @@ def toggle_stack(view):
         if point.size() > 3 and sublime.score_selector(view.scope_name(point.a), 'grld.output.stack.entry'):
             # Get fileuri and line number from selected line in view
             line = view.substr(view.line(point))
-            pattern = re.compile('^(\[\d+\])\s*(?P<fileuri>.*\..*)(\s*:.*?(?P<lineno>\d+))\s*(\((.*?):.*\)|$)')
+            pattern = re.compile('^(\[\d+\])\s*(?P<fileuri>.*\..*)(\s*:.*?(?P<lineno>\d+)).*(\((.*?):.*\)|$)')
             match = pattern.match(line)
             # Show file when it's a valid fileuri
             if match and match.group('fileuri'):


### PR DESCRIPTION
1. Wrong coroutine was selected when debugging code running in a coroutine
2. Couldn't click on all stack frames
3. No error handling for lost connections (also means we couldn't restart/refresh lua and continue to debug) - now restarts the server when a connection is lost (to allow new connections to come in)
4. Error message about not having a path mapping if the path was deeper than the mapping (ex: 'a/b' is mapped, 'a/b/c' would cause a "path not mapped" error message)
5. Correct output for tables in evaluate window